### PR TITLE
Add condition on to use Array.prototype.map

### DIFF
--- a/problems/basic_map/problem.txt
+++ b/problems/basic_map/problem.txt
@@ -23,6 +23,7 @@ Conditions:
 * Do not use any for/while loops.
 * You do not need to define any additional functions
  unless a stub is provided in the boilerplate.
+* Your solution should use Array.prototype.map()
 
 Resources:
 


### PR DESCRIPTION
When I ran through the basic map problem, I didn't put it together
that I was supposed to use Array.prototype.map until I ran a verify
that passed otherwise than not using map.  Think this can be made
clear up front.
