### PR TITLE
Fix trampoline example to trigger Maximum call stack size exceeded

### DIFF
--- a/problems/trampoline/problem.txt
+++ b/problems/trampoline/problem.txt
@@ -18,7 +18,7 @@ BUT note that executing `repeat` with a large `num` causes a stack overflow:
 var count = 0
 repeat(function() {
   count++
-}, 100)
+}, 100000)
 
 console.log('executed %d times', count)
 // => RangeError: Maximum call stack size exceeded


### PR DESCRIPTION
Found this minor typo in the instructions. Let me know what you think.

.. and thanks for a great way to level my js knowledge! :beers:
