### PR TITLE
Fixed issue where Async Loop problem generates duplicate ids.

### DIFF
--- a/problems/async_loops/setup.js
+++ b/problems/async_loops/setup.js
@@ -7,12 +7,42 @@ function randomInt(min, max) {
   return Math.floor((Math.random() * (max - min + 1)) + min)
 }
 
-module.exports = input(new Array(randomInt(10, 20))
-.join(',')
-.split(',')
-.map(function() {
+//http://stackoverflow.com/a/2450976/1011470
+function shuffle(array) {
+  var currentIndex = array.length, temporaryValue, randomIndex ;
+
+  // While there remain elements to shuffle...
+  while (0 !== currentIndex) {
+
+    // Pick a remaining element...
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex -= 1;
+
+    // And swap it with the current element.
+    temporaryValue = array[currentIndex];
+    array[currentIndex] = array[randomIndex];
+    array[randomIndex] = temporaryValue;
+  }
+
+  return array;
+}
+
+function makeArrayOfInts(length, start) {
+  var result = [];
+
+  start = start || 0;
+
+  if (length > 0) {
+    while(result.push(result.length + start) < length);
+  } 
+
+  return result;
+}
+
+module.exports = input(shuffle(makeArrayOfInts(randomInt(10, 20), randomInt(1, 10000)))
+.map(function(currentValue) {
   return {
-    id: randomInt(0, 1000),
+    id: currentValue,
     name: lorem().split(' ').slice(0, 2).map(function(word) {word[0] = word[0].toUpperCase(); return word;}).join(' ')
   }
 })).wrap(function(input, mod) {


### PR DESCRIPTION
The Async Loop problem sometimes fails even using the official solution. I have tested it on three different machines (Mint, OSX and Windows) and I see the same behavior. I wrote a shell script to run the test repeatedly and usually see the issue arise in less than 10 test runs.

The problem is that duplicate id values are often given to users. Here's an example where the 10th and 19th users both got the id 736:

```Shell
assert.js:92
  throw new assert.AssertionError({
        ^
AssertionError: expected: 
[ { id: 408, name: 'Duis Lorem' },
  { id: 919, name: 'Est exercitation' },
  { id: 762, name: 'Pariatur labore' },
  { id: 294, name: 'Labore voluptate' },
  { id: 177, name: 'Anim esse' },
  { id: 146, name: 'Proident in' },
  { id: 678, name: 'Ad deserunt' },
  { id: 867, name: 'Minim ad' },
  { id: 970, name: 'Mollit irure' },
  { id: 736, name: 'Ea aute' },
  { id: 648, name: 'Nostrud ea' },
  { id: 956, name: 'Sit cillum' },
  { id: 889, name: 'Cillum adipisicing' },
  { id: 955, name: 'Laborum ad' },
  { id: 139, name: 'Fugiat cupidatat' },
  { id: 10, name: 'Et ad' },
  { id: 676, name: 'Enim quis' },
  { id: 296, name: 'Dolor esse' },
  { id: 736, name: 'Esse in' },
  { id: 770, name: 'Enim eiusmod' } ]
 but got: 
[ { id: 408, name: 'Duis Lorem' },
  { id: 919, name: 'Est exercitation' },
  { id: 762, name: 'Pariatur labore' },
  { id: 294, name: 'Labore voluptate' },
  { id: 177, name: 'Anim esse' },
  { id: 146, name: 'Proident in' },
  { id: 678, name: 'Ad deserunt' },
  { id: 867, name: 'Minim ad' },
  { id: 970, name: 'Mollit irure' },
  { id: 736, name: 'Ea aute' },
  { id: 648, name: 'Nostrud ea' },
  { id: 956, name: 'Sit cillum' },
  { id: 889, name: 'Cillum adipisicing' },
  { id: 955, name: 'Laborum ad' },
  { id: 139, name: 'Fugiat cupidatat' },
  { id: 10, name: 'Et ad' },
  { id: 676, name: 'Enim quis' },
  { id: 296, name: 'Dolor esse' },
  { id: 736, name: 'Ea aute' },
  { id: 770, name: 'Enim eiusmod' } ]
    at done (eval at <anonymous> (/home/gerrard/.nvm/v0.10.30/lib/node_modules/functional-javascript-workshop/input.js:14:29), <anonymous>:19:12)
    at /home/gerrard/programming/node/nodeschool/async-loops.js:15:12
    at eval [as _onTimeout] (eval at <anonymous> (/home/gerrard/.nvm/v0.10.30/lib/node_modules/functional-javascript-workshop/input.js:14:29), <anonymous>:11:2
```
When the solution calls load load(736) the second time, the user "Ea aute" is returned instead of the expected "Esse in". The underlying problem is that the Random function isn't as random as might be assumed.

Instead of generating completely random id values, I suggest generating a series of integers starting at a random starting point and then shuffling those values. This ensures that duplicate ids will never be generated. 

I have tested this code on my Mint and OSX machines for 100 test runs and I saw no instances of the previously mentioned error.

Please note that I re-used a shuffle algorithm that I found on Stack Overflow to avoid re-inventing the wheel. http://stackoverflow.com/a/2450976/1011470

Thanks for creating a wonderful resource!