### PR TITLE
Corrected order of arguments in the currying example

### DIFF
--- a/problems/currying/problem.md
+++ b/problems/currying/problem.md
@@ -2,9 +2,9 @@ This is an example implementation of `curry3`, which curries up to 3 arguments:
 
 ```js
 function curry3(fun){
-  return function(three){
+  return function(one){
     return function(two){
-      return function (one){
+      return function (three){
         return fun(one, two, three)
       }
     }
@@ -24,10 +24,10 @@ It would work like so:
 
 ```js
 var curryC = curry3(abc)
-var curryB = curryC(2)
+var curryB = curryC(6)
 var curryA = curryB(3)
 
-console.log(curryA(6)) // => 1
+console.log(curryA(2)) // => 1
 ```
 
 # Task


### PR DESCRIPTION
Example with division in "currying" challenge uses inverted order of arguments, i.e. user is supposed to first pass the last argument, then the one before that and so on. The expected solution however uses conventional order.
I've updated problem description to match expected solution.