### PR TITLE
Fully implement map with reduce

### DIFF
--- a/problems/implement_map_with_reduce/solution.js
+++ b/problems/implement_map_with_reduce/solution.js
@@ -1,5 +1,5 @@
-module.exports = function map(arr, fn) {
+module.exports = function map(arr, fn, thisArg) {
   return arr.reduce(function(acc, item, index, arr) {
-    return acc.concat(fn(item, index, arr))
+    return acc.concat(fn.call(thisArg, item, index, arr))
   }, [])
 }


### PR DESCRIPTION
[Array.prototype.arg](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) allows you to pass the context to call the callbacks in.

This is a more complete implementation.