### PR TITLE
Simplify correct solution of Basic: Call

### DIFF
--- a/exercises/basic_call/solution/solution.js
+++ b/exercises/basic_call/solution/solution.js
@@ -1,5 +1,5 @@
 function duckCount() {
-  return Array.prototype.slice.call(arguments).filter(function(obj) {
+  return Array.prototype.filter.call(arguments, function(obj) {
     return Object.prototype.hasOwnProperty.call(obj, 'quack')
   }).length
 }


### PR DESCRIPTION
Instead of turning `arguments` to an array using `slice` and then performing `filter` on it, I propose to bind `arguments` to filter call.

Usually I would even write it like `[].filter.call(…)`, but I agree that would be confusing. (Right?)

According to [Antonov's notes](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments) it is equally slow :)