### PR TITLE
modified implement_map_with_reduce to work with sparse arrays

### DIFF
--- a/exercises/implement_map_with_reduce/solution/solution.js
+++ b/exercises/implement_map_with_reduce/solution/solution.js
@@ -1,6 +1,6 @@
 module.exports = function arrayMap(arr, fn, thisArg) {
   return arr.reduce(function(acc, item, index, arr) {
-    acc.push(fn.call(thisArg, item, index, arr))
+    acc[index] = (fn.call(thisArg, item, index, arr))
     return acc
   }, [])
 }


### PR DESCRIPTION
```acc.push(fn.call(...``` assumes no holes use ```acc[index] = fn.call(...``` instead